### PR TITLE
Allow commands to requery CanExecute from CommandManager

### DIFF
--- a/src/Elmish.WPF/Binding.fs
+++ b/src/Elmish.WPF/Binding.fs
@@ -9,9 +9,13 @@ type Setter<'model,'msg> = obj -> 'model -> 'msg
 type Execute<'model,'msg> = obj -> 'model -> 'msg
 type CanExecute<'model> = obj -> 'model -> bool
 
-type Command(execute, canExecute) =
+type Command(execute, canExecute) as this =
     let canExecuteChanged = Event<EventHandler,EventArgs>()
-    member x.RaiseCanExecuteChanged _ = canExecuteChanged.Trigger(x,EventArgs.Empty)
+    let handler = EventHandler(fun _ _ -> this.RaiseCanExecuteChanged()) 
+    do CommandManager.RequerySuggested.AddHandler(handler)
+    // CommandManager only keeps a weak reference to the event handler, so a strong handler must be maintained
+    member private x._Handler = handler
+    member x.RaiseCanExecuteChanged () = canExecuteChanged.Trigger(x,EventArgs.Empty)
     interface ICommand with
         [<CLIEvent>]
         member x.CanExecuteChanged = canExecuteChanged.Publish


### PR DESCRIPTION
As mentioned in #17, this allows commands to to be requeried for their CanExecute when the CommandManager suggests requerying, such as when the UI changes.  This allows buttons to become enabled/disabled by the state of the UI, even for situations where the model is not updated, such as when the CommandSource is binding the CommandParameter to a UI property.